### PR TITLE
Revert "Fixes windows agents restarting because AppDirectory is not set."

### DIFF
--- a/manifests/set.pp
+++ b/manifests/set.pp
@@ -26,7 +26,6 @@ define nssm::set (
   $service_interactive = false,
   $app_parameters      = undef,
   $nssm_path           = 'C:\Program Files\nssm-2.24\win64',
-  $app_directory       = 'C:\Program Files\nssm-2.24\win64',
 ) {
 
   if $create_user {
@@ -56,13 +55,6 @@ define nssm::set (
     command  => "nssm set '${service_name}' AppParameters '${app_parameters}'",
     path     => $nssm_path,
     unless   => "[Console]::OutputEncoding = [System.Text.Encoding]::Unicode; \$args = nssm get '${service_name}' AppParameters; \$cmp = \$args.Contains(\"${app_parameters}\"); if (\$cmp -eq \"True\") {exit 0} else {exit 1}",
-    provider => powershell,
-  }
-
-  exec { 'set_app_directory':
-    command  => "nssm set '${service_name}' AppDirectory '${app_directory}'",
-    path     => $nssm_path,
-    unless   => "[Console]::OutputEncoding = [System.Text.Encoding]::Unicode; \$args = nssm get '${service_name}' AppDirectory; \$cmp = \$args.Contains(\"${app_directory}\"); if (\$cmp -eq \"True\") {exit 0} else {exit 1}",
     provider => powershell,
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ktreese-nssm",
-  "version": "1.1.0",
+  "version": "1.0.2",
   "author": "Kris Reese",
   "summary": "Manages nssm with Puppet",
   "license": "Apache-2.0",


### PR DESCRIPTION
Reverts merge into master.  The fix may actually lie with the using $args as a variable within the execs (seems powershell no longer likes that!)