### PR TITLE
Renames args variable to 'a'

### DIFF
--- a/manifests/set.pp
+++ b/manifests/set.pp
@@ -48,21 +48,21 @@ define nssm::set (
   exec { 'set_service_name':
     command  => $command,
     path     => $nssm_path,
-    unless   => "[Console]::OutputEncoding = [System.Text.Encoding]::Unicode; \$args = nssm get '${service_name}' ObjectName; \$cmp = \$args.Contains(\"${service_user}\"); if (\$cmp -eq \"True\") {exit 0} else {exit 1}",
+    unless   => "[Console]::OutputEncoding = [System.Text.Encoding]::Unicode; \$a = nssm get '${service_name}' ObjectName; \$cmp = \$a.Contains(\"${service_user}\"); if (\$cmp -eq \"True\") {exit 0} else {exit 1}",
     provider => powershell,
   }
 
   exec { 'set_app_parameters':
     command  => "nssm set '${service_name}' AppParameters '${app_parameters}'",
     path     => $nssm_path,
-    unless   => "[Console]::OutputEncoding = [System.Text.Encoding]::Unicode; \$args = nssm get '${service_name}' AppParameters; \$cmp = \$args.Contains(\"${app_parameters}\"); if (\$cmp -eq \"True\") {exit 0} else {exit 1}",
+    unless   => "[Console]::OutputEncoding = [System.Text.Encoding]::Unicode; \$a = nssm get '${service_name}' AppParameters; \$cmp = \$a.Contains(\"${app_parameters}\"); if (\$cmp -eq \"True\") {exit 0} else {exit 1}",
     provider => powershell,
   }
 
   exec { 'set_app_directory':
     command  => "nssm set '${service_name}' AppDirectory '${app_directory}'",
     path     => $nssm_path,
-    unless   => "[Console]::OutputEncoding = [System.Text.Encoding]::Unicode; \$args = nssm get '${service_name}' AppDirectory; \$cmp = \$args.Contains(\"${app_directory}\"); if (\$cmp -eq \"True\") {exit 0} else {exit 1}",
+    unless   => "[Console]::OutputEncoding = [System.Text.Encoding]::Unicode; \$a = nssm get '${service_name}' AppDirectory; \$cmp = \$a.Contains(\"${app_directory}\"); if (\$cmp -eq \"True\") {exit 0} else {exit 1}",
     provider => powershell,
   }
 
@@ -70,7 +70,7 @@ define nssm::set (
     exec { 'set_service_interactive_process':
       command  => "nssm reset '${service_name}' ObjectName; nssm set '${service_name}' Type SERVICE_INTERACTIVE_PROCESS",
       path     => $nssm_path,
-      unless   => "[Console]::OutputEncoding = [System.Text.Encoding]::Unicode; \$args = nssm get '${service_name}' Type; \$cmp = \$args.Contains(\"INTERACTIVE\"); if (\$cmp -eq \"True\") {exit 0} else {exit 1}",
+      unless   => "[Console]::OutputEncoding = [System.Text.Encoding]::Unicode; \$a = nssm get '${service_name}' Type; \$cmp = \$a.Contains(\"INTERACTIVE\"); if (\$cmp -eq \"True\") {exit 0} else {exit 1}",
       provider => powershell,
     }
   }


### PR DESCRIPTION
Powershell no longer likes the use of `$args` as a variable.  Not sure why at this point (as this used to work) though it seems to be a reserved word.