### PR TITLE
Changes dir to nssm_path to avoid CommandNotFoundException

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -30,7 +30,7 @@ define nssm::install (
     exec { 'install_service_name':
       command  => "nssm install '${service_name}' '${program}'",
       path     => $nssm_path,
-      unless   => "nssm get '${service_name}' Name",
+      unless   => "cd '${nssm_path}'; nssm get '${service_name}' Name",
       provider => powershell,
     }
   }
@@ -39,7 +39,7 @@ define nssm::install (
     exec { 'remove_service_name':
       command  => "nssm remove '${service_name}' confirm",
       path     => $nssm_path,
-      onlyif   => "nssm get '${service_name}' Name",
+      onlyif   => "cd '${nssm_path}'; nssm get '${service_name}' Name",
       provider => powershell,
     }
   }

--- a/manifests/set.pp
+++ b/manifests/set.pp
@@ -47,14 +47,14 @@ define nssm::set (
   exec { 'set_service_name':
     command  => $command,
     path     => $nssm_path,
-    unless   => "[Console]::OutputEncoding = [System.Text.Encoding]::Unicode; \$a = nssm get '${service_name}' ObjectName; \$cmp = \$a.Contains(\"${service_user}\"); if (\$cmp -eq \"True\") {exit 0} else {exit 1}",
+    unless   => "cd '${nssm_path}';[Console]::OutputEncoding = [System.Text.Encoding]::Unicode; \$a = nssm get '${service_name}' ObjectName; \$cmp = \$a.Contains(\"${service_user}\"); if (\$cmp -eq \"True\") {exit 0} else {exit 1}",
     provider => powershell,
   }
 
   exec { 'set_app_parameters':
     command  => "nssm set '${service_name}' AppParameters '${app_parameters}'",
     path     => $nssm_path,
-    unless   => "[Console]::OutputEncoding = [System.Text.Encoding]::Unicode; \$a = nssm get '${service_name}' AppParameters; \$cmp = \$a.Contains(\"${app_parameters}\"); if (\$cmp -eq \"True\") {exit 0} else {exit 1}",
+    unless   => "cd '${nssm_path}'; [Console]::OutputEncoding = [System.Text.Encoding]::Unicode; \$a = nssm get '${service_name}' AppParameters; \$cmp = \$a.Contains(\"${app_parameters}\"); if (\$cmp -eq \"True\") {exit 0} else {exit 1}",
     provider => powershell,
   }
 
@@ -62,7 +62,7 @@ define nssm::set (
     exec { 'set_service_interactive_process':
       command  => "nssm reset '${service_name}' ObjectName; nssm set '${service_name}' Type SERVICE_INTERACTIVE_PROCESS",
       path     => $nssm_path,
-      unless   => "[Console]::OutputEncoding = [System.Text.Encoding]::Unicode; \$a = nssm get '${service_name}' Type; \$cmp = \$a.Contains(\"INTERACTIVE\"); if (\$cmp -eq \"True\") {exit 0} else {exit 1}",
+      unless   => "cd '${nssm_path}'; [Console]::OutputEncoding = [System.Text.Encoding]::Unicode; \$a = nssm get '${service_name}' Type; \$cmp = \$a.Contains(\"INTERACTIVE\"); if (\$cmp -eq \"True\") {exit 0} else {exit 1}",
       provider => powershell,
     }
   }


### PR DESCRIPTION
The following exec types began throwing a `CommandNotFoundException` relative to the `unless` attributes specified within the type.  This used to work just fine without, so it's unclear what has caused the exception to pop up.

Regardless, this merge is to cd into the path of the nssm binary, then run the command to avoid errors such as the following:

/Stage[main]/Jenkins_windows_agent/Nssm::Install[Jenkins_Agent]/Exec[install_service_name]/unless: nssm : The term 'nssm' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.

This issue pertains to both the `nssm::install` and `nssm::set` defined types, particularly in the following exec resources:

- `exec[install_service_name]`
- `exec[set_service_name]`